### PR TITLE
fix build broken by license text changes

### DIFF
--- a/comparelogs.py
+++ b/comparelogs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 mbed tools
 Copyright (c) 2018 ARM Limited
@@ -11,9 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-
-#!/usr/bin/env python
 
 import sys
 

--- a/json_set.py
+++ b/json_set.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 mbed tools
 Copyright (c) 2018 ARM Limited
@@ -12,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-
-#!/usr/bin/env python
 #
 # You can use command-line tools like 'jq' but they may not
 # be common or available for your system. Python is common
@@ -57,7 +56,7 @@ if __name__ == '__main__':
 
     with open(args.filename, 'r') as f:
         data = json.load(f)
-    
+
     # Set the value
     result = set(data, args.key, args.value)
 

--- a/tools/combine_bootloader_with_app.py
+++ b/tools/combine_bootloader_with_app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 mbed tools
 Copyright (c) 2018 ARM Limited
@@ -11,10 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-
-#!/usr/bin/env python
-
 from os import path
 import hashlib, zlib, struct
 import time

--- a/tools/merge_json.py
+++ b/tools/merge_json.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 mbed tools
 Copyright (c) 2018 ARM Limited
@@ -11,9 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-
-#!/usr/bin/env python
 
 import argparse
 import json


### PR DESCRIPTION
the first line of a script must start with a shebang so that
the script can be executed properly.

Signed-off-by: Nic Costa <nic.costa@arm.com>