### PR TITLE
Update manifest tool to public 1.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ patchclean:
 .PHONY: distclean
 distclean: clean certclean
 	for lib in ${LIBS}; do rm -rf $${lib%.lib}; done
-	rm -rf manifest-tool-restricted
+	rm -rf manifest-tool
 	rm -rf mbed-cloud-client-restricted
 	rm -rf mbed-bootloader-restricted
 	rm -f .deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mbed-cli==1.2.2
-git+ssh://git@github.com/ARMmbed/manifest-tool-restricted.git@v1.2
+git+ssh://git@github.com/ARMmbed/manifest-tool.git@v1.3.2
 git+ssh://git@github.com/ARMmbed/mbed-cloud-update-cli.git


### PR DESCRIPTION
Update manifest tool to be appropriate for GA release. This means changing the repo and the version.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>