### PR TITLE
fix and re-enable factory reset

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1006,6 +1006,9 @@ static int platform_init()
     Keystore k;
     bool factory_reset;
 
+    /* check if the user wants to perform a factory reset */
+    factory_reset = check_factory_reset();
+
 #if MBED_CONF_MBED_TRACE_ENABLE
     /* Create mutex for tracing to avoid broken lines in logs */
     if (!mbed_trace_helper_create_mutex()) {
@@ -1029,8 +1032,8 @@ static int platform_init()
     display.init(MBED_CONF_APP_VERSION);
     display.refresh();
 
-    /* check if the user wants to perform a factory reset */
-    factory_reset = check_factory_reset();
+    /* now that we have the fs and display up, perform the factory reset
+     * if so requested */
     if (factory_reset) {
         do_factory_reset();
     }


### PR DESCRIPTION
the main fix was to set the DigitalIn::mode to PullUp before reading
the button.  the change was required due to a missing pull up resistor
R34 which wasn't populated on the WEM.

a timeout was also added such that the user has to hold the button
down for a configurable number of (default 5) seconds before the
factory reset is carried out.

the timeout can be configured at compile time by setting a value for
config.factory-reset-button-press-secs in mbed_app.json or by
changing MBED_CONF_APP_FACTORY_RESET_BUTTON_PRESS_SECS in main.cpp.

Signed-off-by: Nic Costa <nic.costa@arm.com>