### PR TITLE
reset FCC explicitly when performing factory reset

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -972,12 +972,21 @@ static void do_factory_reset()
     ret = fs_format();
     if (0 != ret) {
         cmd.printf("ERROR: fs format failed: %d\n", ret);
-    } else {
-        display_evq_id = 0;
-        // Display "Factory Reset" message
-        display.set_erasing();
-        display.set_default_view();
+        return;
     }
+
+    /* formatting the fs isn't enough to reset fcc */
+    fcc_init();
+    ret = fcc_storage_delete();
+    if (ret != FCC_STATUS_SUCCESS) {
+        cmd.printf("ERROR: fcc delete failed: %d\n", ret);
+    }
+    fcc_finalize();
+
+    display_evq_id = 0;
+    // Display "Factory Reset" message
+    display.set_erasing();
+    display.set_default_view();
 }
 
 static bool check_factory_reset()


### PR DESCRIPTION
it was shown that simply formatting the FS isn't sufficient to
clear out the FCC certs to reset it to a pre-bootstrap state.
doing so resulted in a device that was incapable of registering to
the mbed cloud.

Signed-off-by: Nic Costa <nic.costa@arm.com>