### PR TITLE
v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build this project, you need to install the following:
     sudo apt-get install gcc-arm-embedded
     ```
 
-3. Python 2.7 and pip.
+3. Python 2.7.12+ and pip 9.0.3.
 
     On a Mac, pip and virtualenv are not preinstalled. Here is how to install them:
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mbed-cli==1.2.2
+mbed-cli==1.8.3
 git+ssh://git@github.com/ARMmbed/manifest-tool.git@v1.3.2
 git+ssh://git@github.com/ARMmbed/mbed-cloud-update-cli.git


### PR DESCRIPTION
    v1.0.4

    * Support newer Mbed-CLI version 1.8.3
            * this fixes a Makefile breakage for folks running the
              newer version.
            * the older version 1.2.2 placed the output files in
              a different path, thus breaking the Makefile

    * Support minimum version of Python 2.7.12
            * this fixes a build breakage issue due to an upstream
              component with an unversioned dependency